### PR TITLE
feat: Add Cassette Beasts provider and fetch functionality

### DIFF
--- a/fetch_names_manager.py
+++ b/fetch_names_manager.py
@@ -1,4 +1,5 @@
 import requests
+import json
 
 class FetchNamesManager:
     
@@ -22,6 +23,8 @@ class FetchNamesManager:
                 return []
             elif mode == "palworld":
                 return cls.fetch_palworld_names()
+            elif mode == "cassettebeasts":
+                return cls.fetch_cassette_beasts_names()
             else:
                 return []
         except Exception as e:
@@ -85,6 +88,29 @@ class FetchNamesManager:
             return []
         except Exception as e:
             print(f"Error fetching Coromon names: {e}")
+            return []
+    
+    @classmethod
+    def fetch_cassette_beasts_names(cls) -> list:
+        try:
+            cargo_url = "https://wiki.cassettebeasts.com/api.php"
+            params = {
+                "action": "parse",
+                "page": "Data:Species",
+                "prop": "wikitext",
+                "format": "json"
+            }
+            r = requests.get(cargo_url, params=params)
+            all_names = []
+            if r.status_code == 200:
+                responsejson = r.json()
+                raw_json = responsejson["parse"]["wikitext"]["*"]
+                species_data = json.loads(raw_json)
+                all_names.extend([species["name"] for species in species_data])
+                return all_names
+            return []
+        except Exception as e:
+            print(f"Error fetching Cassette Beasts names: {e}")
             return []
     
     @classmethod

--- a/providers.json
+++ b/providers.json
@@ -1,4 +1,8 @@
 {
+  "cassettebeasts": {
+    "enabled": true,
+    "label": "Cassette Beasts"
+  },
   "coromon": {
     "enabled": true,
     "label": "Coromon"

--- a/static/providers/cassettebeasts.js
+++ b/static/providers/cassettebeasts.js
@@ -1,0 +1,50 @@
+import { CreatureProvider } from "./baseProvider.js";
+import { validateURL, fetchJSON } from "./commonProvider.js";
+
+/**
+ * Provider for Cassette Beasts creatures
+ * @author Djinnet
+ */
+export class CassetteBeastsProvider extends CreatureProvider {
+    constructor() {
+        super("cassettebeasts", "Cassette Beasts", true);
+        this.API_URL = "https://wiki.cassettebeasts.com/api.php";
+    }
+
+    //TODO: optimize this to avoid fetching the entire species list each time
+    async validate(name) {
+        if (!name) return false;
+        const json = await fetchJSON(this.API_URL, {
+            action: "parse",
+            format: "json",
+            page: "Data:Species",
+            prop: "wikitext",
+            formatversion: 2
+        });
+        const raw_json = json?.parse?.wikitext;
+        if (!raw_json) return false;
+        const species_data = JSON.parse(raw_json);
+        const names = species_data.map(s => s.name);
+        //check if name exists in species_data
+        if (names.includes(name)) return true;
+        return false;
+
+    }
+
+    async getSprite(name) {
+        if (!name) return null;
+
+        const images_json = await fetchJSON(this.API_URL, {
+            action: "query",
+            format: "json",
+            titles: `File:${name}.png`,
+            prop: "imageinfo",
+            iiprop: "url",
+            formatversion: 2
+        });
+        const file_url = images_json?.query?.pages[0]?.imageinfo?.[0]?.url;
+
+        if (!validateURL(file_url)) return null;
+        return file_url;
+    }
+}

--- a/static/providers/commonProvider.js
+++ b/static/providers/commonProvider.js
@@ -14,6 +14,21 @@ export function validateThumbnail(thumb) {
 }
 
 /**
+ * Validate a URL
+ * @param {*} url 
+ * @returns {boolean} - true if valid, false otherwise
+ */
+export function validateURL(url) {
+    if (!url) return false;
+    try {
+        const parsedURL = new URL(url);
+        return parsedURL.protocol === "http:" || parsedURL.protocol === "https:";
+    } catch (e) {
+        return false;
+    }
+}
+
+/**
  * Fetch JSON data from a REST API endpoint
  * @param {*} API_URL - The API endpoint URL
  * @param {*} params - Query parameters for the request

--- a/static/script.js
+++ b/static/script.js
@@ -4,6 +4,7 @@ import { TemtemProvider } from "./providers/temtem.js";
 import { CoromonProvider } from "./providers/coromon.js";
 import { KindredFatesProvider } from "./providers/kindredfates.js";
 import { PalworldProvider } from "./providers/palworld.js";
+import { CassetteBeastsProvider } from "./providers/cassettebeasts.js";
 import { loadNames, sendName, sendMode, sendGeneration, sendAction } from "./common.js";
 
 // this contains all available providers (modes)
@@ -13,7 +14,8 @@ const providers = {
     temtem: new TemtemProvider(),
     coromon: new CoromonProvider(),
     kindredfates: new KindredFatesProvider(),
-    palworld: new PalworldProvider()
+    palworld: new PalworldProvider(),
+    cassettebeasts: new CassetteBeastsProvider(),
 };
 
 /**
@@ -41,7 +43,7 @@ async function nameValidate(name, mode) {
         }
         return await provider.validate(name);
     } catch (error) {
-        alert("An error occurred while validating the name.");
+        alert("An error occurred while validating the name. Error: " + error.message);
         return false;
     }
 }


### PR DESCRIPTION
This pull request adds support for Cassette Beasts as a new provider across both the backend and frontend. The changes include implementing name fetching and validation logic for Cassette Beasts, updating configuration files, and integrating the new provider into the application's main provider registry. The most important changes are grouped below:

**Backend: Cassette Beasts Name Support**
* Added a new method `fetch_cassette_beasts_names` to `FetchNamesManager` to fetch Cassette Beasts species names from the official wiki API, and updated the `fetch_names` method to support the `"cassettebeasts"` mode. [[1]](diffhunk://#diff-3aca12707ea0c41c16a203cf2debb0fadce97196c56fd8f72d844b513909cd49R26-R27) [[2]](diffhunk://#diff-3aca12707ea0c41c16a203cf2debb0fadce97196c56fd8f72d844b513909cd49R93-R115)
* Imported the `json` module to enable parsing of the Cassette Beasts species data.

**Configuration: Provider Enablement**
* Added Cassette Beasts as an enabled provider in `providers.json` with an appropriate label.

**Frontend: Cassette Beasts Provider Integration**
* Implemented `CassetteBeastsProvider` in `static/providers/cassettebeasts.js` to handle name validation and sprite fetching using the Cassette Beasts wiki API.
* Registered `CassetteBeastsProvider` in the main provider registry in `static/script.js`, making it available in the application. [[1]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3R7) [[2]](diffhunk://#diff-91d78b631f73e5c7378c8415a1acf56325e3d53d019f1c16cba60d3622a251a3L16-R18)

**Frontend: Utility Improvements**
* Added a `validateURL` utility function in `static/providers/commonProvider.js` to check if a URL is valid and uses HTTP or HTTPS, used by the new provider.
* Improved error messaging in the name validation function to include the actual error message.